### PR TITLE
fix: hits.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 being unproductive
 
-![Hits](https://hits.link/hits?url=https%3A%2F%2Fgithub.com%2FMilo123459&bgRight=aa88ff)
+![Hits](https://hits-app.vercel.app/hits?url=https%3A%2F%2Fgithub.com%2FMilo123459&bgRight=aa88ff)


### PR DESCRIPTION
we've recently dropped the hits.link domain because the renewal price was $180, please use the updated/stable one :D!

sorry for the inconvenience!